### PR TITLE
🔧 Env: add Docker, .dockerignore, change webpack.config.js

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Items that don't need to be in a Docker image.
+# Anything not used by the build system should go here.
+Dockerfile
+.dockerignore
+.gitignore
+README.md
+
+# Artifacts that will be built during image creation.
+# This should contain all files created during `npm run build`.
+build
+node_modules
+.next

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+# Step 1: 기본 이미 구동을 위한 Node.js
+FROM node:18-alpine
+
+# Step 2: 이미지에서 구동할 폴더
+WORKDIR /app
+
+# Step 3: 패키지 정보 복사
+COPY package.json yarn.lock ./
+
+# Step 4: 패키지 설치
+RUN yarn install
+
+# Step 5: 나머지 프로젝트 파일을 복사
+COPY . .
+
+# Step 6: 해당 어플리케이션이 구동할 포트번호 열어주기
+EXPOSE 3000
+
+# Step 7: dev환경 구동하기
+CMD ["yarn", "dev"]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,8 @@ const config = {
   devServer: {
     open: true,
     historyApiFallback: true,
-    host: 'localhost',
+    host: '0.0.0.0', // Bind to all interfaces
+    port: 3000,
   },
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
closes #22 

## What was changed
- Add DockerFile, .dockerignore file

## Newly learned

### Container localhost

I am using `webpack-dev-server` for development env.
However, when the app is dockerized, the `localhost` becomes container itself.

Therefore, before change, I cannot access 127.0.0.1:3000 as specified in docker cli command below.
I should have changed webpack devserver host to `0.0.0.0` to open to all network interfaces.


### Docker CLi
I learned how to create image with <imagename>:<tagname>.
`latest`tag automatically follows when I create the image without tag.

```
docker build -t react-test:test .   
docker run -dp 127.0.0.1:3000:3000 react-test:test
```

